### PR TITLE
Updates to install without multiple SSH connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the instance every few minutes or so until it is successful.  You want to be car
 
 These types of instances are meant to be spun up when you need some decent GPU power for cracking hashes, and you should terminate them as soon as you are done in order to avoid large fees, especially the `p3.16xlarge`.
 
-The full set of installed packages takes around 15GB of space to install. After install around 3GB can be freed with `apt clean all`. It's recommended to use a root disk of at least 16GB on your instances.
+The full set of installed packages takes around 15GB of space to install. After install around 3GB will be freed with `apt clean all`. It's recommended to use a root disk of at least 16GB on your instances.
 
 ## Installation
 
@@ -27,11 +27,11 @@ cd aws-hashcat
 
 Your instance will reboot 3 times:
 
-- 1: after running `./install.sh`
-- 2: after logging in via `ssh` a second time
-- 3: after logging in via `ssh` a third time
+- 1: After installing all package updates.
+- 2: After installing hashcat, nvidia drivers and applying kernel module configuration.
+- 3: After installing cuda.
 
-When logging in the 4th time, you will be ready to run `hashcat`, which will already be installed with all necessary GPU drivers.
+After the 3rd reboot, you will be ready to run `hashcat`, which will already be installed with all necessary GPU drivers.
 
 ### Please note:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aws-hashcat
 
-This is a quickstart process to install all the necessary GPU drivers and options for `hashcat` on Ubuntu 20.04 AWS instances.
+This is a quickstart process to install all the necessary GPU drivers and options for `hashcat` on Ubuntu 20.04 and 22.04 AWS instances.
 
 The following may not be an exhaustive list, but I know that the following instance types are compatible:
 
@@ -12,6 +12,8 @@ The `p3.16xlarge` requires a [service limit increase](https://console.aws.amazon
 the instance every few minutes or so until it is successful.  You want to be careful running this type of instance.  It is *NOT* for long-term use.
 
 These types of instances are meant to be spun up when you need some decent GPU power for cracking hashes, and you should terminate them as soon as you are done in order to avoid large fees, especially the `p3.16xlarge`.
+
+The full set of installed packages takes around 15GB of space to install. After install around 3GB can be freed with `apt clean all`. It's recommended to use a root disk of at least 16GB on your instances.
 
 ## Installation
 

--- a/install.sh
+++ b/install.sh
@@ -1,26 +1,49 @@
 #!/bin/bash
 
-if [[ $UID -eq 0 ]]; then
+dir='/etc/awshashcat'
+# The first run will be manual, the rest automatic as root.
+if [[ $UID -eq 0 ]] && [[ ! -f $dir/00_install.LCK ]]; then
   echo 'Please run this script without sudo as a non-root user.'
   exit 1
 fi
 
+WARN=0
+if [[ -z $(which lsb_release) ]]; then
+  echo "lsb_release missing, this is not a target distribution."
+  WARN=1
+else
+  RELEASE=$(lsb_release -r | awk '{print $2}')
+  if [[ $RELEASE != '20.04' ]] && [[ $RELEASE != '22.04' ]]; then
+    echo "Release $RELEASE is not 20.04 or 22.04."
+    WARN=1
+  fi
+fi
+
+if [[ $WARN -eq 1 ]]; then
+  echo ">>> WARNING -- WARNING -- WARNING <<<"
+  echo "Supported distributions are Ubuntu 20.04 and 22.04"
+  echo "Continuing anyway, but this will probably fail."
+  echo ""
+fi
+
 cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)
 scriptdir="$PWD"
-dir='/etc/awshashcat'
 
 echo -e '\nChecking hashcat readiness...'
 sudo mkdir -p "$dir"
 
 # STAGE 1/3
 if [[ ! -f "${dir}/00_install.LCK" ]]; then
-  echo -e "\n${scriptdir}/install.sh\n" >> "${HOME}/.bashrc"
+  sudo bash -c 'echo "#!/bin/bash" >/etc/rc.local'
+  sudo bash -c "echo -e \"\n${scriptdir}/install.sh  # HASHCAT INSTALL SCRIPT\" >> /etc/rc.local"
+  sudo chmod +x /etc/rc.local
+  sudo cp rc-local.service /etc/systemd/system/rc-local.service
+  sudo systemctl enable rc-local
   sudo apt update -y
   sudo apt dist-upgrade -y
   echo '
 System will go down for 3 reboots during the upgrade/installation process.
-You will have to login for the 2nd and 3rd reboots to complete.
-Upon your 3rd time logging in, you should be ready to get cracking.
+After the third reboot your system will be ready to use.
 
 System going down for reboot [1/3]...
 '
@@ -31,24 +54,23 @@ fi
 
 # STAGE 2/3
 if [[ ! -f "${dir}/01_drivers.LCK" ]]; then
-  echo -e '\nConfiguring drivers...\n'
   sudo "${scriptdir}/scripts/01_drivers.sh"
-  echo -e '\nSystem going down for reboot [2/3]...\n'
-  sudo touch "${dir}/01_drivers.LCK"
+  touch "${dir}/01_drivers.LCK"
   sleep 5
-  sudo reboot
+  reboot
 fi
 
 # STAGE 3/3
 if [[ ! -f "${dir}/02_cuda.LCK" ]]; then
-  echo -e '\nInstalling cuda...\n'
   sudo "${scriptdir}/scripts/02_cuda.sh"
-  echo -e '\nSystem going down for reboot [3/3]...\n'
-  sudo touch "${dir}/02_cuda.LCK"
+  touch "${dir}/02_cuda.LCK"
   sleep 5
-  sudo reboot
+  reboot
 fi
 
-echo -e '\nhashcat is ready.'
+sed -i '/# HASHCAT INSTALL SCRIPT/d' /etc/rc.local
 
-echo -e "\nTo check nvidia status, run 'sudo nvidia-smi'.\n"
+echo "echo -e 'hashcat is ready.\n'" >>/etc/profile.d/hashcat.sh
+
+echo "echo -e \"To check nvidia status, run 'sudo nvidia-smi'.\n\"" >>/etc/profile.d/hashcat.sh
+

--- a/rc-local.service
+++ b/rc-local.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=/etc/rc.local Compatibility
+ConditionPathExists=/etc/rc.local
+
+[Service]
+Type=forking
+ExecStart=/etc/rc.local start
+TimeoutSec=0
+StandardOutput=tty
+RemainAfterExit=yes
+SysVStartPriority=99
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/01_drivers.sh
+++ b/scripts/01_drivers.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-sudo apt-get update -yq
-sudo apt-get install -yq hashcat build-essential linux-headers-$(uname -r) unzip p7zip-full linux-image-extra-virtual
+apt-get update -yq
+apt-get install -yq hashcat build-essential linux-headers-$(uname -r) unzip p7zip-full linux-image-extra-virtual
 
-sudo touch /etc/modprobe.d/blacklist-nouveau.conf
-sudo bash -c "echo 'blacklist nouveau' >> /etc/modprobe.d/blacklist-nouveau.conf"
-sudo bash -c "echo 'blacklist lbm-nouveau' >> /etc/modprobe.d/blacklist-nouveau.conf"
-sudo bash -c "echo 'options nouveau modeset=0' >> /etc/modprobe.d/blacklist-nouveau.conf"
-sudo bash -c "echo 'alias nouveau off' >> /etc/modprobe.d/blacklist-nouveau.conf"
-sudo bash -c "echo 'alias lbm-nouveau off' >> /etc/modprobe.d/blacklist-nouveau.conf"
+touch /etc/modprobe.d/blacklist-nouveau.conf
+bash -c "echo 'blacklist nouveau' >> /etc/modprobe.d/blacklist-nouveau.conf"
+bash -c "echo 'blacklist lbm-nouveau' >> /etc/modprobe.d/blacklist-nouveau.conf"
+bash -c "echo 'options nouveau modeset=0' >> /etc/modprobe.d/blacklist-nouveau.conf"
+bash -c "echo 'alias nouveau off' >> /etc/modprobe.d/blacklist-nouveau.conf"
+bash -c "echo 'alias lbm-nouveau off' >> /etc/modprobe.d/blacklist-nouveau.conf"
 
-sudo touch /etc/modprobe.d/nouveau-kms.conf
-sudo bash -c "echo 'options nouveau modeset=0' >>  /etc/modprobe.d/nouveau-kms.conf"
-sudo update-initramfs -u
+touch /etc/modprobe.d/nouveau-kms.conf
+bash -c "echo 'options nouveau modeset=0' >>  /etc/modprobe.d/nouveau-kms.conf"
+update-initramfs -u

--- a/scripts/02_cuda.sh
+++ b/scripts/02_cuda.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
-sudo apt-get update -y
-sudo apt-get -y install cuda
+mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+apt-get update -y
+apt-get -y install cuda
+
+apt-get clean all


### PR DESCRIPTION
I made the following changes:

This not sets up /etc/rc.local and adds the install script in there so it automatically runs after a reboot instead of needing human initiated ssh connections.

As everything but the first run are run as root I removed many sudos. I'm not sure if you will like the security implications of this but Ubuntu is a root equivalent account anyway as it can run anything via sudo with no authentication. The security implications between running this as ubuntu and root are not much.

I updated the README.

This is tested with a few hashes on both Ubuntu 20.04 and Ubuntu 22.04. It works great on both but Ubuntu 22.04 comes with a later hashcat so should be preferred.
