### PR TITLE
Update for Ubuntu 26.04 / Add wordlist and rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,36 @@ Your instance will reboot 3 times:
 - 2: After installing hashcat, nvidia drivers and applying kernel module configuration.
 - 3: After installing cuda.
 
-After the 3rd reboot, you will be ready to run `hashcat`, which will already be installed with all necessary GPU drivers.
+After the 3rd reboot, `install.sh` will also download wordlists and rules to `/opt/wordlists/`.
 
+## Included wordlists & rules
+
+After installation, the following assets are available in `/opt/wordlists/`:
+
+| File | Description | Size |
+|---|---|---|
+| `ultimate-wpa2-clean.txt` | The ultimate wordlist from https://github.com/kennyn510/wpa2-wordlists.git (~7.2M unique passwords). | ~78 MB |
+| `OneRuleToRuleThemAll.rule` | A high-performing hashcat ruleset that generates common password mutations on the fly. | ~2 KB |
+
+### Using the wordlists
+
+Basic hashcat wordlist attack (`-a 0`):
+
+```bash
+hashcat -m 1000 -a 0 hashes.txt /opt/wordlists/ultimate-wpa2-clean.txt
+```
+
+With the ruleset applied to generate mutations:
+
+```bash
+hashcat -m 1000 -a 0 hashes.txt /opt/wordlists/ultimate-wpa2-clean.txt -r /opt/wordlists/OneRuleToRuleThemAll.rule
+```
+
+### Why rulesets?
+
+Rulesets like **OneRuleToRuleThemAll** apply hundreds of common transformations such as case changes, leet-speak substitutions, appending numbers/symbols, and so on to each word in the list. This generates millions of additional candidates at almost no disk cost.
 
 ### Please note:
 
-This repo does not come with any pre-installed wordlists or rules.
-
-I may add a script to download some rules and wordlists, as well as a helper script at some point in the future,
-but for now this remains BYOA (Bring Your Own Assets).
-
-Right now, this repo is simply used to help make the best use of your time while setting up a hashcat-ready AWS instance so you can get to cracking ASAP. 
+You can always add your own wordlists by copying them to `/opt/wordlists/`. The included RockYou + OneRuleToRuleThemAll combination covers the vast majority of common passwords, but targeted lists (e.g., company-specific terms) can improve results for specific engagements.
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # aws-hashcat
 
-This is a quickstart process to install all the necessary GPU drivers and options for `hashcat` on Ubuntu 20.04 and 22.04 AWS instances.
+This is a quickstart process to install all the necessary GPU drivers and options for `hashcat` on Ubuntu 26.04 AWS instances.
 
-The following may not be an exhaustive list, but I know that the following instance types are compatible:
+Any Nvidia GPU instance should work, but getting quota can be a nightmare on AWS. g5 instances come with A10G Tensor Core GPUs, which are plenty fast and currently offer the best hashrate per dollar.
 
-- g4dn.xlarge ($0.53 per hour)
-- g3s.xlarge ($0.75 per hour)
-- p3.16xlarge ($24.48 per hour - watch out for this guy, he's expensive)
+- g5.xlarge   - 1 GPU  - $1.006 per hour (us-east-1)
+- g5.12xlarge - 4 GPUs - $5.672 per hour (us-east-1)
 
-The `p3.16xlarge` requires a [service limit increase](https://console.aws.amazon.com/support/home?#/case/create) for your account, and availability can actually be limited at times, depending on region, so you may have to keep trying to launch
-the instance every few minutes or so until it is successful.  You want to be careful running this type of instance.  It is *NOT* for long-term use.
+These types of instances are meant to be spun up when you need some decent GPU power for cracking hashes. You should terminate them as soon as you are done in order to avoid large fees.
 
-These types of instances are meant to be spun up when you need some decent GPU power for cracking hashes, and you should terminate them as soon as you are done in order to avoid large fees, especially the `p3.16xlarge`.
+The OS and full set of installed packages takes around 20GB. After install around 3GB will be freed with `apt clean all`. It's recommended to use a root disk of at least 25GB on your instances.
 
-The full set of installed packages takes around 15GB of space to install. After install around 3GB will be freed with `apt clean all`. It's recommended to use a root disk of at least 16GB on your instances.
 
 ## Installation
 
@@ -32,6 +29,7 @@ Your instance will reboot 3 times:
 - 3: After installing cuda.
 
 After the 3rd reboot, you will be ready to run `hashcat`, which will already be installed with all necessary GPU drivers.
+
 
 ### Please note:
 

--- a/install.sh
+++ b/install.sh
@@ -13,16 +13,16 @@ if [[ -z $(which lsb_release) ]]; then
   WARN=1
 else
   RELEASE=$(lsb_release -r | awk '{print $2}')
-  if [[ $RELEASE != '20.04' ]] && [[ $RELEASE != '22.04' ]]; then
-    echo "Release $RELEASE is not 20.04 or 22.04."
+  if [[ $RELEASE != '26.04' ]]; then
+    echo "Release $RELEASE is not 26.04."
     WARN=1
   fi
 fi
 
 if [[ $WARN -eq 1 ]]; then
   echo ">>> WARNING -- WARNING -- WARNING <<<"
-  echo "Supported distributions are Ubuntu 20.04 and 22.04"
-  echo "Continuing anyway, but this will probably fail."
+  echo "Supported distribution is Ubuntu 26.04"
+  echo "Continuing anyway."
   echo ""
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ scriptdir="$PWD"
 echo -e '\nChecking hashcat readiness...'
 sudo mkdir -p "$dir"
 
-# STAGE 1/3
+# STAGE 1/4
 if [[ ! -f "${dir}/00_install.LCK" ]]; then
   sudo bash -c 'echo "#!/bin/bash" >/etc/rc.local'
   sudo bash -c "echo -e \"\n${scriptdir}/install.sh  # HASHCAT INSTALL SCRIPT\" >> /etc/rc.local"
@@ -52,7 +52,7 @@ System going down for reboot [1/3]...
   sudo reboot
 fi
 
-# STAGE 2/3
+# STAGE 2/4
 if [[ ! -f "${dir}/01_drivers.LCK" ]]; then
   sudo "${scriptdir}/scripts/01_drivers.sh"
   touch "${dir}/01_drivers.LCK"
@@ -60,7 +60,7 @@ if [[ ! -f "${dir}/01_drivers.LCK" ]]; then
   reboot
 fi
 
-# STAGE 3/3
+# STAGE 3/4
 if [[ ! -f "${dir}/02_cuda.LCK" ]]; then
   sudo "${scriptdir}/scripts/02_cuda.sh"
   touch "${dir}/02_cuda.LCK"
@@ -68,9 +68,17 @@ if [[ ! -f "${dir}/02_cuda.LCK" ]]; then
   reboot
 fi
 
+# STAGE 4/4
+if [[ ! -f "${dir}/03_wordlists.LCK" ]]; then
+  sudo "${scriptdir}/scripts/03_wordlists.sh"
+  touch "${dir}/03_wordlists.LCK"
+fi
+
 sed -i '/# HASHCAT INSTALL SCRIPT/d' /etc/rc.local
 
 echo "echo -e 'hashcat is ready.\n'" >>/etc/profile.d/hashcat.sh
 
 echo "echo -e \"To check nvidia status, run 'sudo nvidia-smi'.\n\"" >>/etc/profile.d/hashcat.sh
+
+echo "echo -e \"Wordlists and rules are in /opt/wordlists/.'\n\"" >>/etc/profile.d/hashcat.sh
 

--- a/scripts/02_cuda.sh
+++ b/scripts/02_cuda.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+keyring=cuda-keyring_1.1-1_all.deb
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/${keyring} -O /tmp/${keyring}
+dpkg -i /tmp/${keyring}
+
+add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/ /"
 apt-get update -y
 apt-get -y install cuda
 

--- a/scripts/03_wordlists.sh
+++ b/scripts/03_wordlists.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+WORDLIST_DIR="/opt/wordlists"
+mkdir -p "$WORDLIST_DIR"
+
+cd "$WORDLIST_DIR"
+
+echo "[*] Downloading wpa2-wordlists ultimate list (~28 MB)..."
+wget https://github.com/kennyn510/wpa2-wordlists/releases/download/ultimate2016-clean/ultimate-wpa2-clean.txt.gz
+
+echo "[*] Unzipping wpa2-wordlist ultimate list (~78 MB)..."
+gunzip ultimate-wpa2-clean.txt.gz
+
+echo "[*] Downloading OneRuleToRuleThemAll ruleset..."
+wget -q --show-progress https://raw.githubusercontent.com/NotSoSecure/password_cracking_rules/master/OneRuleToRuleThemAll.rule -O OneRuleToRuleThemAll.rule
+
+echo "[*] Wordlists and rules downloaded to $WORDLIST_DIR"
+echo ""
+ls -lh "$WORDLIST_DIR"


### PR DESCRIPTION
This PR:

- Updates for Ubuntu 26.04
- Adds the Ultimate wordlist from wpa-wordlists (https://github.com/kennyn510/wpa2-wordlists)
- Adds the OneRuleToRuleThemAll rule file.
- Updated README with instructions to use the above wordlist and rule file.

The wordlist above assumes we are cracking WPA2 passwords, but all that seems to mean is don't even try passwords less than 8 chars. That may not be reasonable for cracking other things.